### PR TITLE
New Settings

### DIFF
--- a/BaseFeatures.cs
+++ b/BaseFeatures.cs
@@ -89,6 +89,9 @@ namespace MonstrumExtendedSettingsMod
                 // No Steam
                 On.SteamVentManager.Awake += new On.SteamVentManager.hook_Awake(HookSteamVentManager);
 
+                // Silent SteamVents
+                On.SteamVents.Start += new On.SteamVents.hook_Start(HookSteamVentsStart);
+
                 // Colour & Light Settings (Except Brute Light and Ship Generic Light)
                 On.Flashlight.Start += new On.Flashlight.hook_Start(HookFlashlightStart);
                 On.GlowStick.Start += new On.GlowStick.hook_Start(HookGlowStick);
@@ -8300,6 +8303,19 @@ namespace MonstrumExtendedSettingsMod
                     return;
                 }
                 steamVentManager.masterControlOverride = false;
+            }
+
+            /*----------------------------------------------------------------------------------------------------*/
+            // @SteamVents
+            
+            private static void HookSteamVentsStart(On.SteamVents.orig_Start orig, SteamVents steamVents)
+            {
+                orig.Invoke(steamVents);
+                if (ModSettings.silentSteamVents)
+                {
+                    steamVents.blastSource.mute = true;
+                    steamVents.ventSource.mute = true;
+                }
             }
 
             /*----------------------------------------------------------------------------------------------------*/

--- a/BaseFeatures.cs
+++ b/BaseFeatures.cs
@@ -7303,7 +7303,7 @@ namespace MonstrumExtendedSettingsMod
             }
 
             /*----------------------------------------------------------------------------------------------------*/
-            // @SecurityCamera
+            // @AmberState
 
             private static void HookAmberStateCtor(On.AmberState.orig_ctor orig, AmberState amberState)
             {

--- a/BaseFeatures.cs
+++ b/BaseFeatures.cs
@@ -46,6 +46,9 @@ namespace MonstrumExtendedSettingsMod
                 // Player Movement Speed
                 On.PlayerMotor.ClampSpeed += new On.PlayerMotor.hook_ClampSpeed(HookPlayerMotorClampSpeed);
 
+                //Disable Workshop Phones
+                On.Phone.Start += new On.Phone.hook_Start(HookPhoneStart);
+
                 // Monster Selection, Seed, Starter Room Location & Wallhacks Mode
                 HookLevelGeneration();
                 On.AudioLibrary.GetNext += new On.AudioLibrary.hook_GetNext(HookAudioLibraryGetNext);
@@ -2962,6 +2965,18 @@ namespace MonstrumExtendedSettingsMod
                 catch
                 {
                     Debug.Log("Could not modify KeyItemSystem.");
+                }
+            }
+
+            /*----------------------------------------------------------------------------------------------------*/
+            // @Phone
+
+            private static void HookPhoneStart(On.Phone.orig_Start orig, Phone phone)
+            {
+                orig.Invoke(phone);
+                if (ModSettings.disableWorkshopPhones)
+                {
+                    phone.phoneDestroyed = true;
                 }
             }
 

--- a/ModSettings.cs
+++ b/ModSettings.cs
@@ -1196,6 +1196,8 @@ namespace MonstrumExtendedSettingsMod
                     randomStartRoom = new MESMSetting<bool>("Random Start Room", "Lets the player spawn in a random room in the ship rather than the standard start room", false).userValue;
                     noPitTraps = new MESMSetting<bool>("No Pit Traps", "Destroys all pit traps when starting the game", false).userValue;
                     noDoors = new MESMSetting<bool>("No Doors", "Destroys all doors except the submersible room doors when starting the game", false).userValue;
+                    spawnAdditionalEggtimers = new MESMSetting<int>("Spawn additional Eggtimers", "Spawns additional Eggtimers in the spawn room", 0, false, false, 0).userValue;
+                    spawnAdditionalFuses = new MESMSetting<int>("Spawn additional Fuses", "Spawns additional Fuses in the spawn room", 0, false, false, 0).userValue;
 
                     // Read Colour Settings Variables
                     modSettingsErrorString = "Colour";
@@ -1815,6 +1817,8 @@ namespace MonstrumExtendedSettingsMod
                     }
                 }
 
+                int spawnEggtimerCount = spawnAdditionalEggtimers;
+                int spawnFuseCount = spawnAdditionalFuses;
                 if (useCustomDoors)
                 {
                     if (lightlyLockedDoors)
@@ -1832,16 +1836,7 @@ namespace MonstrumExtendedSettingsMod
                             fusebox.transform.parent.GetComponentInChildren<FuseBoxLever>().PullLever(false);
                         }
 
-                        Transform referenceTransform = References.Player.transform;
-                        if (!randomStartRoom)
-                        {
-                            referenceTransform = FindObjectOfType<TutorialFlashlight>().transform;
-                        }
-
-                        for (int i = 0; i < 40; i++)
-                        {
-                            UnityEngine.Object.Instantiate<GameObject>(UnityEngine.Object.FindObjectOfType<Fuse>().gameObject, referenceTransform.position + referenceTransform.up + referenceTransform.forward, referenceTransform.rotation);
-                        }
+                        spawnFuseCount += 40;
                     }
                     else if (ModSettings.customDoorTypeNumber == 5)
                     {
@@ -1854,17 +1849,13 @@ namespace MonstrumExtendedSettingsMod
                             }
                         }
 
-                        Transform referenceTransform = References.Player.transform;
-                        if (!randomStartRoom)
-                        {
-                            referenceTransform = FindObjectOfType<TutorialFlashlight>().transform;
-                        }
-
-                        for (int i = 0; i < 40; i++)
-                        {
-                            UnityEngine.Object.Instantiate<GameObject>(UnityEngine.Object.FindObjectOfType<EggTimer>().gameObject, referenceTransform.position + referenceTransform.up + referenceTransform.forward, referenceTransform.rotation);
-                        }
+                        spawnEggtimerCount += 40;
                     }
+                }
+
+                if (spawnFuseCount > 0 || spawnEggtimerCount > 0)
+                {
+                    SpawnFusesAndEggtimers(spawnFuseCount, spawnEggtimerCount);
                 }
 
                 if (spawnWithLiferaftItems || spawnWithHelicopterItems || spawnWithSubmersibleItems)
@@ -2347,6 +2338,25 @@ namespace MonstrumExtendedSettingsMod
 
                 Debug.Log("READ LATE EXTENDED SETTINGS (AFTER GENERATION INITIALISATION)");
                 Debug.LogError("READ LATE EXTENDED SETTINGS (AFTER GENERATION INITIALISATION)");
+            }
+
+            private static void SpawnFusesAndEggtimers(int fuses, int eggtimers)
+            {
+                Transform referenceTransform = References.Player.transform;
+                if (!randomStartRoom)
+                {
+                    referenceTransform = FindObjectOfType<TutorialFlashlight>().transform;
+                }
+
+                for (int i = 0; i < fuses; i++)
+                {
+                    UnityEngine.Object.Instantiate<GameObject>(UnityEngine.Object.FindObjectOfType<Fuse>().gameObject, referenceTransform.position + referenceTransform.up + referenceTransform.forward, referenceTransform.rotation);
+                }
+
+                for (int i = 0; i < eggtimers; i++)
+                {
+                    UnityEngine.Object.Instantiate<GameObject>(UnityEngine.Object.FindObjectOfType<EggTimer>().gameObject, referenceTransform.position + referenceTransform.up + referenceTransform.forward, referenceTransform.rotation);
+                }
             }
 
             public static void AssignCustomMusic()
@@ -3907,6 +3917,8 @@ namespace MonstrumExtendedSettingsMod
             public static bool randomStartRoom;
             public static bool noPitTraps;
             public static bool noDoors;
+            public static int spawnAdditionalEggtimers;
+            public static int spawnAdditionalFuses;
             public static bool experimentalShipExtension = false;
 
 

--- a/ModSettings.cs
+++ b/ModSettings.cs
@@ -1169,6 +1169,7 @@ namespace MonstrumExtendedSettingsMod
                     extendLowerDecks = new MESMSetting<bool>("Extend Lower Decks", "A setting that has a similar effect to the extend map one, but only affects the lower decks and has much faster loading times. Also increases the spawn count of lower deck rooms a tiny bit to help fill the additional space", false).userValue;
                     spawnAdditionalEngineRoomWorkshops = new MESMSetting<bool>("Spawn Additional Engine Room Workshops", "Spawns some more engine room workshops with phones", false).userValue;
                     aggressiveWorkshopSpawning = new MESMSetting<bool>("Aggressive Workshop Spawning", "Replaces nodes dedicated to decorative multi-floor engines by nodes that can spawn more workshops", false, false, true).userValue;
+                    disableWorkshopPhones = new MESMSetting<bool>("Disable Workshop Phones", "Disables all phones in the engine room, even when the power is on", false, false, true).userValue;
                     numberOfCorridorsToCargoHoldFromDeckThree = new MESMSetting<int>("Number Of Corridors To Cargo Hold From Deck Three", "Lets one or both sides of deck 3 connect to the cargo hold. If the Use Deck Four On Submersible Side setting is enabled, then it will also similarly connect to the cargo hold. You can use 0, 1 or 2", 0, false, false, 0, 2).userValue; // Mathf.Clamp(Convert.ToInt32(FindSetting("Number Of Corridors To Cargo Hold From Deck Three")), 0, 2);
                     reduceNormalNumberOfCorridorsToCargoHold = new MESMSetting<int>("Reduce Normal Number Of Corridors To Cargo Hold", "Stops one or both sides of deck 1 and 2 on the submersible side and deck 3 and 4 on the engine side from connecting to the cargo hold. You can use 0, 1 or 2", 0, false, false, 0, 2).userValue; // Mathf.Clamp(Convert.ToInt32(FindSetting("Reduce Normal Number Of Corridors To Cargo Hold")), 0, 2);
                     lengthenedCargoHoldCorridors = new MESMSetting<bool>("Lengthened Cargo Hold Corridors", "Lets corridors going to the cargo hold go through the entire ship, not just to one side of the cargo hold", false).userValue;
@@ -3879,6 +3880,7 @@ namespace MonstrumExtendedSettingsMod
             public static bool extendLowerDecks;
             public static bool spawnAdditionalEngineRoomWorkshops;
             public static bool aggressiveWorkshopSpawning;
+            public static bool disableWorkshopPhones;
             public static int numberOfCorridorsToCargoHoldFromDeckThree;
             public static int reduceNormalNumberOfCorridorsToCargoHold;
             public static bool lengthenedCargoHoldCorridors;

--- a/ModSettings.cs
+++ b/ModSettings.cs
@@ -1,4 +1,4 @@
-// ~Beginning Of File
+﻿// ~Beginning Of File
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -1089,6 +1089,7 @@ namespace MonstrumExtendedSettingsMod
                     gravityXComponent = new MESMSetting<float>("Gravity X Acceleration", "Changes the acceleration due to gravity in the x axis", 0f, false).userValue;
                     gravityYComponent = new MESMSetting<float>("Gravity Y Acceleration", "Changes the acceleration due to gravity in the y axis", -9.81f, false, true).userValue;
                     gravityZComponent = new MESMSetting<float>("Gravity Z Acceleration", "Changes the acceleration due to gravity in the z axis", 0f, false, true).userValue;
+                    camTimer = new MESMSetting<float>("Camera Timer", "Sets the timer for how long a camera needs until it triggers its alarm", 2f, true, false, 0f).userValue;
 
                     // Read Player and Item Settings Variables
                     // Read Player Settings Variables
@@ -1149,7 +1150,6 @@ namespace MonstrumExtendedSettingsMod
                     consistentLevelGeneration = new MESMSetting<bool>("Consistent Level Generation", "Level generation for the same seed and settings will always be the same. This is setting is automatically enabled when using a custom seed", false, false, true).userValue;
                     startRoomRegion = new MESMSettingMultipleChoice("Starter Room Region", "Can be Upper Deck, Lower Deck or Either", "Either", new string[] { "Either", "Upper Deck", "Lower Deck" }).userValue;
                     spawnDeactivatedItems = new MESMSetting<bool>("Spawn Deactivated Items", "Lets the compass and walkie talkie items spawn. These items were spawned in older versions of the game, but later removed", false).userValue;
-                    camTimer = new MESMSetting<int>("Camera Timer", "Sets the timer for how long a camera needs until it triggers its alarm", 2, true, false, 0).userValue;
                     noCameras = new MESMSetting<bool>("No Cameras", "All cameras are covered with duct tape", false).userValue;
                     noSteam = new MESMSetting<bool>("No Steam", "Sets the engine room's steam override to off. Model does not update", false).userValue;
                     preFillStartRegionFuseBox = new MESMSetting<bool>("Pre-fill Start Region Fuse Box", "Pre-fills the fuse box of the player's start region", true).userValue;
@@ -3808,6 +3808,7 @@ namespace MonstrumExtendedSettingsMod
             public static float gravityXComponent;
             public static float gravityYComponent;
             public static float gravityZComponent;
+            public static float camTimer;
 
 
 
@@ -3859,7 +3860,6 @@ namespace MonstrumExtendedSettingsMod
             public static string startRoomRegion;
             public static bool spawnDeactivatedItems;
             public static bool noCameras;
-            public static int camTimer;
             public static bool noSteam;
             public static bool preFillStartRegionFuseBox;
             public static bool preFillLiferaftFuseBox;

--- a/ModSettings.cs
+++ b/ModSettings.cs
@@ -1090,6 +1090,7 @@ namespace MonstrumExtendedSettingsMod
                     gravityYComponent = new MESMSetting<float>("Gravity Y Acceleration", "Changes the acceleration due to gravity in the y axis", -9.81f, false, true).userValue;
                     gravityZComponent = new MESMSetting<float>("Gravity Z Acceleration", "Changes the acceleration due to gravity in the z axis", 0f, false, true).userValue;
                     camTimer = new MESMSetting<float>("Camera Timer", "Sets the timer for how long a camera needs until it triggers its alarm", 2f, true, false, 0f).userValue;
+                    silentSteamVents = new MESMSetting<bool>("Silent Steam Vents", "The steam vents will not make any noise", false).userValue;
 
                     // Read Player and Item Settings Variables
                     // Read Player Settings Variables
@@ -3809,6 +3810,7 @@ namespace MonstrumExtendedSettingsMod
             public static float gravityYComponent;
             public static float gravityZComponent;
             public static float camTimer;
+            public static bool silentSteamVents;
 
 
 

--- a/Monstrum/MESM Readme.txt
+++ b/Monstrum/MESM Readme.txt
@@ -117,6 +117,13 @@ Bug Fixes:
 - Improved consistency of no starter fuse setting.
 - Fixed inventory escape condition in multiplayer.
 - Fixed Fire Blast and Sparky chase electric traps not working in V7.0.
+-----
+Hotfixes up to 28.06.2026
+- Hotfixed speedrun timer being re-recorded if clicking fast to escape.
+- Fixed player still sometimes being hit by fire or steam by Brute with Fire Shroud.
+- Fixed submarine being disabled after interact even with escape conditions.
+- Fixed flare gun not always spawning in escape conditions.
+- Fixed custom slow aura factor not being applied.
 ------------------------------------------------------------
 Monstrum Extended Settings Mod V7.0 (Partiality) — 29.03.2026
 -----


### PR DESCRIPTION
- Changed Camera Timer Setting & Code position
- Added Setting "Silent Steam Vents", to turn off the vent & steam burst sounds of the Steam Vents in Lower Deck
- Added Setting "Disable Workshop Phones" to prevent players to use the Phones to distract the Monster
- Added Setting "Spawn additional Eggtimers" & "Spawn additional Fuses" to give the players extra eggtimers or fuses at the start of the round. In addition, the code to spawn eggtimers and fuses for specific door types has been move into its own function