### PR TITLE
Add camera detection settings and player health configurations

### DIFF
--- a/BaseFeatures.cs
+++ b/BaseFeatures.cs
@@ -7328,14 +7328,24 @@ namespace MonstrumExtendedSettingsMod
             private static void HookAlarmManagerStartPlayingSound(On.AlarmManager.orig_StartPlayingSound orig, AlarmManager alarmManager, Vector3 _audioTransform, Room _cameraRoom)
             {
                 orig.Invoke(alarmManager, _audioTransform, _cameraRoom);
-                NewPlayerClass newPlayerClass = FindObjectOfType<NewPlayerClass>();
+                NewPlayerClass player;
+                if (ModSettings.enableMultiplayer)
+                {
+                    player = MultiplayerMode.crewPlayers[MultiplayerMode.ClosestPlayerToThis(_audioTransform, true)];
+                }
+                else
+                {
+                    player = FindObjectOfType<NewPlayerClass>();
+                }
+
                 if (ModSettings.camDetectDMGValue > 0)
                 {
-                    newPlayerClass.playerMotor.pHealth.DoDamage(ModSettings.camDetectDMGValue, false, PlayerHealth.DamageTypes.Steam, false);
+                    player.playerMotor.pHealth.DoDamage(ModSettings.camDetectDMGValue, false, PlayerHealth.DamageTypes.Steam, false);
                 }
+
                 if (ModSettings.doCameraStun)
                 {
-                    newPlayerClass.PushBackDir = 1f;
+                    player.PushBackDir = 1f;
                 }
             }
 

--- a/BaseFeatures.cs
+++ b/BaseFeatures.cs
@@ -86,6 +86,9 @@ namespace MonstrumExtendedSettingsMod
                 //Cameras Timer
                 On.AmberState.ctor += new On.AmberState.hook_ctor(HookAmberStateCtor);
 
+                // Hurt Player on detection
+                On.AlarmManager.StartPlayingSound += new On.AlarmManager.hook_StartPlayingSound(HookAlarmManagerStartPlayingSound);
+
                 // No Steam
                 On.SteamVentManager.Awake += new On.SteamVentManager.hook_Awake(HookSteamVentManager);
 
@@ -7308,6 +7311,23 @@ namespace MonstrumExtendedSettingsMod
             private static void HookAmberStateCtor(On.AmberState.orig_ctor orig, AmberState amberState)
             {
                 amberState.warningTime = ModSettings.camTimer;
+            }
+
+            /*----------------------------------------------------------------------------------------------------*/
+            // @AlarmManager
+            
+            private static void HookAlarmManagerStartPlayingSound(On.AlarmManager.orig_StartPlayingSound orig, AlarmManager alarmManager, Vector3 _audioTransform, Room _cameraRoom)
+            {
+                orig.Invoke(alarmManager, _audioTransform, _cameraRoom);
+                NewPlayerClass newPlayerClass = FindObjectOfType<NewPlayerClass>();
+                if (ModSettings.camDetectDMGValue > 0)
+                {
+                    newPlayerClass.playerMotor.pHealth.DoDamage(ModSettings.camDetectDMGValue, false, PlayerHealth.DamageTypes.Steam, false);
+                }
+                if (ModSettings.doCameraStun)
+                {
+                    newPlayerClass.PushBackDir = 1f;
+                }
             }
 
             /*----------------------------------------------------------------------------------------------------*/

--- a/BaseFeatures.cs
+++ b/BaseFeatures.cs
@@ -1153,6 +1153,33 @@ namespace MonstrumExtendedSettingsMod
             }
 
             /*----------------------------------------------------------------------------------------------------*/
+            // @AlarmManager
+            
+            private static void HookAlarmManagerStartPlayingSound(On.AlarmManager.orig_StartPlayingSound orig, AlarmManager alarmManager, Vector3 _audioTransform, Room _cameraRoom)
+            {
+                orig.Invoke(alarmManager, _audioTransform, _cameraRoom);
+                NewPlayerClass player;
+                if (ModSettings.enableMultiplayer)
+                {
+                    player = MultiplayerMode.crewPlayers[MultiplayerMode.ClosestPlayerToThis(_audioTransform, true)];
+                }
+                else
+                {
+                    player = FindObjectOfType<NewPlayerClass>();
+                }
+
+                if (ModSettings.camDetectDMGValue > 0)
+                {
+                    player.playerMotor.pHealth.DoDamage(ModSettings.camDetectDMGValue, false, PlayerHealth.DamageTypes.Steam, false);
+                }
+
+                if (ModSettings.doCameraStun)
+                {
+                    player.PushBackDir = 1f;
+                }
+            }
+
+            /*----------------------------------------------------------------------------------------------------*/
             // @AnimationControl
 
             /// <summary>
@@ -7320,33 +7347,6 @@ namespace MonstrumExtendedSettingsMod
             private static void HookAmberStateCtor(On.AmberState.orig_ctor orig, AmberState amberState)
             {
                 amberState.warningTime = ModSettings.camTimer;
-            }
-
-            /*----------------------------------------------------------------------------------------------------*/
-            // @AlarmManager
-            
-            private static void HookAlarmManagerStartPlayingSound(On.AlarmManager.orig_StartPlayingSound orig, AlarmManager alarmManager, Vector3 _audioTransform, Room _cameraRoom)
-            {
-                orig.Invoke(alarmManager, _audioTransform, _cameraRoom);
-                NewPlayerClass player;
-                if (ModSettings.enableMultiplayer)
-                {
-                    player = MultiplayerMode.crewPlayers[MultiplayerMode.ClosestPlayerToThis(_audioTransform, true)];
-                }
-                else
-                {
-                    player = FindObjectOfType<NewPlayerClass>();
-                }
-
-                if (ModSettings.camDetectDMGValue > 0)
-                {
-                    player.playerMotor.pHealth.DoDamage(ModSettings.camDetectDMGValue, false, PlayerHealth.DamageTypes.Steam, false);
-                }
-
-                if (ModSettings.doCameraStun)
-                {
-                    player.PushBackDir = 1f;
-                }
             }
 
             /*----------------------------------------------------------------------------------------------------*/

--- a/BaseFeatures.cs
+++ b/BaseFeatures.cs
@@ -110,11 +110,13 @@ namespace MonstrumExtendedSettingsMod
                 On.PlayerMotor.HandleFallDamage += new On.PlayerMotor.hook_HandleFallDamage(HookPlayerMotorHandleFallDamage);
                 //On.TutorialLockerModelSwap.Update += new On.TutorialLockerModelSwap.hook_Update(HookTutorialLockerModelSwap); // Debug text & Death countdown were moved to MonsterStarter.
 
+                // Player Max Health & Recovery
+                On.PlayerHealth.Start += new On.PlayerHealth.hook_Start(HookPlayerHealthStart);
+
                 Debug.Log("INITIALISED BASE FEATURES");
 
                 // No Brute Light & Brute Light Colour
                 HookLightShafts();
-
 
                 // Indev / New Area
 
@@ -6643,6 +6645,13 @@ namespace MonstrumExtendedSettingsMod
 
             /*----------------------------------------------------------------------------------------------------*/
             // @PlayerHealth
+            
+            private static void HookPlayerHealthStart(On.PlayerHealth.orig_Start orig, PlayerHealth playerHealth)
+            {
+                playerHealth.MaxHP = ModSettings.maxHealth;
+                playerHealth.recoveryValue = ModSettings.recoveryValue;
+                orig.Invoke(playerHealth);
+            }
 
             private static void HookPlayerHealth()
             {

--- a/ModSettings.cs
+++ b/ModSettings.cs
@@ -1098,7 +1098,7 @@ namespace MonstrumExtendedSettingsMod
                     MESMSetting.currentCategoryBeingAssigned = modSettingsErrorString + " Settings";
                     extraLives = new MESMSetting<int>("Extra Lives", "Allows you to teleport back to the starter room instead of dying if you have additional lives remaining. Also gives a few seconds of spawn protection", 0).userValue;
                     maxHealth = new MESMSetting<int>("Player Max Health", "Changes the player's maximum health", 100, true).userValue;
-                    recoveryValue = new MESMSetting<int>("Player Health Recovery", "Changes the player's recovery speed", 1, true).userValue;
+                    recoveryValue = new MESMSetting<int>("Player Health Recovery", "Defines how much health the player recovers each frame after not taking damage for a set duration", 1, true).userValue; // Not every Second due to "currentHP = Mathf.CeilToInt(currentHP + (float)recoveryValue * Time.deltaTime);"
                     inventorySize = new MESMSetting<int>("Inventory Size", "Changes how many inventory slots you have when starting a game", 0).userValue;
                     minimumValueOnFOVSlider = new MESMSetting<float>("Minimum Value On FOV Slider", "Allows you to customise your FOV Slider. Set minimum to -180 and maximum to 180 for full range of FOVs. This sets the minimum value of the FOV slider", 50).userValue;
                     maximumValueOnFOVSlider = new MESMSetting<float>("Maximum Value On FOV Slider", "Allows you to customise your FOV Slider. Set minimum to -180 and maximum to 180 for full range of FOVs. This sets the maximum value of the FOV slider", 70, false, true).userValue;

--- a/ModSettings.cs
+++ b/ModSettings.cs
@@ -1097,6 +1097,8 @@ namespace MonstrumExtendedSettingsMod
                     modSettingsErrorString = "Player and Item";
                     MESMSetting.currentCategoryBeingAssigned = modSettingsErrorString + " Settings";
                     extraLives = new MESMSetting<int>("Extra Lives", "Allows you to teleport back to the starter room instead of dying if you have additional lives remaining. Also gives a few seconds of spawn protection", 0).userValue;
+                    maxHealth = new MESMSetting<int>("Player Max Health", "Changes the player's maximum health", 100, true).userValue;
+                    recoveryValue = new MESMSetting<int>("Player Health Recovery", "Changes the player's recovery speed", 1, true).userValue;
                     inventorySize = new MESMSetting<int>("Inventory Size", "Changes how many inventory slots you have when starting a game", 0).userValue;
                     minimumValueOnFOVSlider = new MESMSetting<float>("Minimum Value On FOV Slider", "Allows you to customise your FOV Slider. Set minimum to -180 and maximum to 180 for full range of FOVs. This sets the minimum value of the FOV slider", 50).userValue;
                     maximumValueOnFOVSlider = new MESMSetting<float>("Maximum Value On FOV Slider", "Allows you to customise your FOV Slider. Set minimum to -180 and maximum to 180 for full range of FOVs. This sets the maximum value of the FOV slider", 70, false, true).userValue;
@@ -3816,6 +3818,8 @@ namespace MonstrumExtendedSettingsMod
             // Player and Item Settings Variables
             // Player Settings Variables
             public static int extraLives;
+            public static int maxHealth;
+            public static int recoveryValue;
             public static int inventorySize;
             public static float minimumValueOnFOVSlider;
             public static float maximumValueOnFOVSlider;

--- a/ModSettings.cs
+++ b/ModSettings.cs
@@ -1,4 +1,4 @@
-// ~Beginning Of File
+﻿// ~Beginning Of File
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -1089,6 +1089,8 @@ namespace MonstrumExtendedSettingsMod
                     gravityXComponent = new MESMSetting<float>("Gravity X Acceleration", "Changes the acceleration due to gravity in the x axis", 0f, false).userValue;
                     gravityYComponent = new MESMSetting<float>("Gravity Y Acceleration", "Changes the acceleration due to gravity in the y axis", -9.81f, false, true).userValue;
                     gravityZComponent = new MESMSetting<float>("Gravity Z Acceleration", "Changes the acceleration due to gravity in the z axis", 0f, false, true).userValue;
+                    doCameraStun = new MESMSetting<bool>("Camera Detection Stun", "Defines whether the player gets stunned when detected by a camera", false).userValue;
+                    camDetectDMGValue = new MESMSetting<float>("Camera Detection Damage", "Defines how much damage the player takes when detected by a camera", 0f).userValue;
 
                     // Read Player and Item Settings Variables
                     // Read Player Settings Variables
@@ -3808,8 +3810,8 @@ namespace MonstrumExtendedSettingsMod
             public static float gravityXComponent;
             public static float gravityYComponent;
             public static float gravityZComponent;
-
-
+            public static bool doCameraStun;
+            public static float camDetectDMGValue;
 
             // Player and Item Settings Variables
             // Player Settings Variables


### PR DESCRIPTION
- #14 
- #21 
### Added New Settings
- **Camera Detection Stun**: Stuns the player if seen by an camera
- **Camera Detection Damage**: Damage the player by the given value if seen by an camera
- **Player Max Health**: Sets the maximum health of the Player
- **Player Health Recovery**: Sets the recovery value of the player. If set to 0, the player will no longer recover from any damage