### PR TITLE
Setting "Silent Steam Vents"

### DIFF
--- a/BaseFeatures.cs
+++ b/BaseFeatures.cs
@@ -89,6 +89,9 @@ namespace MonstrumExtendedSettingsMod
                 // No Steam
                 On.SteamVentManager.Awake += new On.SteamVentManager.hook_Awake(HookSteamVentManager);
 
+                // Silent SteamVents
+                On.SteamVents.Start += new On.SteamVents.hook_Start(HookSteamVentsStart);
+
                 // Colour & Light Settings (Except Brute Light and Ship Generic Light)
                 On.Flashlight.Start += new On.Flashlight.hook_Start(HookFlashlightStart);
                 On.GlowStick.Start += new On.GlowStick.hook_Start(HookGlowStick);
@@ -8300,6 +8303,19 @@ namespace MonstrumExtendedSettingsMod
                     return;
                 }
                 steamVentManager.masterControlOverride = false;
+            }
+
+            /*----------------------------------------------------------------------------------------------------*/
+            // @SteamVents
+            
+            private static void HookSteamVentsStart(On.SteamVents.orig_Start orig, SteamVents steamVents)
+            {
+                orig.Invoke(steamVents);
+                if (ModSettings.silentSteamVents)
+                {
+                    steamVents.blastSource.mute = true;
+                    steamVents.ventSource.mute = true;
+                }
             }
 
             /*----------------------------------------------------------------------------------------------------*/

--- a/ModSettings.cs
+++ b/ModSettings.cs
@@ -1,4 +1,4 @@
-// ~Beginning Of File
+﻿// ~Beginning Of File
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -1089,6 +1089,7 @@ namespace MonstrumExtendedSettingsMod
                     gravityXComponent = new MESMSetting<float>("Gravity X Acceleration", "Changes the acceleration due to gravity in the x axis", 0f, false).userValue;
                     gravityYComponent = new MESMSetting<float>("Gravity Y Acceleration", "Changes the acceleration due to gravity in the y axis", -9.81f, false, true).userValue;
                     gravityZComponent = new MESMSetting<float>("Gravity Z Acceleration", "Changes the acceleration due to gravity in the z axis", 0f, false, true).userValue;
+                    silentSteamVents = new MESMSetting<bool>("Silent Steam Vents", "The steam vents will not make any noise", false).userValue;
 
                     // Read Player and Item Settings Variables
                     // Read Player Settings Variables
@@ -3808,7 +3809,7 @@ namespace MonstrumExtendedSettingsMod
             public static float gravityXComponent;
             public static float gravityYComponent;
             public static float gravityZComponent;
-
+            public static bool silentSteamVents;
 
 
             // Player and Item Settings Variables


### PR DESCRIPTION
- Added new Setting "Silent Steam Vents": The Lower Deck Steam Vents do not make any noises if bursting or if they are about to burst